### PR TITLE
feat(versions): modernize Terraform and provider versions

### DIFF
--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## Describe your changes

Modernizes Terraform and provider version constraints to current standards.

- **`versions.tf`**: Updated `required_version` from `>= 1.3` to `>= 1.9`
- **`versions.tf`**: Updated `azurerm` provider from `~> 3.22` to `~> 3.116`
- **`examples/basic/versions.tf`**: Created with matching provider constraints (azurerm only, as the example calls the provider directly while other providers are pulled in by the module)

Other providers (`null`, `local`, `tls`, `azurenoopsutils`, `azurecaf`) were left unchanged — their existing loose constraints remain compatible. No changes to resource logic, variables, outputs, locals, or module structure.

> **Note:** `azurerm 4.x` is now GA. The `~> 3.116` constraint intentionally pins to the 3.x line due to breaking changes in 4.x. If 4.x support is desired in the future, the constraint can be updated to `>= 3.116, < 5.0`.

## Issue number

#4

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.