### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-bastionvm
+  name: terraform-az-overlays-bastionvm
   description: Terraform overlay module for Azure Bastion jump-box VM
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-bastionvm
+    github.com/project-slug: POps-Rox/terraform-az-overlays-bastionvm
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-bastionvm
+    - url: https://github.com/POps-Rox/terraform-az-overlays-bastionvm
       title: GitHub Repository
       icon: github
 spec:

--- a/resources.bastion.virtual.machine.tf
+++ b/resources.bastion.virtual.machine.tf
@@ -1,8 +1,8 @@
 # TODO: Update module call to match current tf-az-overlays-virtualmachine API
 # The module arguments have changed significantly since this was written.
-# See https://github.com/POps-Rox/tf-az-overlays-virtualmachine for current API.
+# See https://github.com/POps-Rox/terraform-az-overlays-virtualmachine for current API.
 #
 # module "bastion_vm" {
-#   source = "github.com/POps-Rox/tf-az-overlays-virtualmachine"
+#   source = "github.com/POps-Rox/terraform-az-overlays-virtualmachine"
 #   ...
 # }


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.